### PR TITLE
refa(parser): remove pratt parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,6 @@ name = "parser"
 version = "0.1.0"
 dependencies = [
  "ast",
- "lazy_static",
  "pest",
  "pest_derive",
  "utils",

--- a/frontend/ast/src/impls.rs
+++ b/frontend/ast/src/impls.rs
@@ -10,10 +10,22 @@ impl Continue {
 	}
 }
 
+impl Default for Continue {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
 impl Break {
 	pub fn new() -> Break {
 		Break {
 			_attrs: HashMap::new(),
 		}
+	}
+}
+
+impl Default for Break {
+	fn default() -> Self {
+		Self::new()
 	}
 }

--- a/frontend/ast/src/lib.rs
+++ b/frontend/ast/src/lib.rs
@@ -23,10 +23,10 @@ pub enum BinaryOp {
 	Mul,
 	Div,
 	Mod,
-	LQ,
+	LT,
 	LE,
 	GE,
-	GQ,
+	GT,
 	EQ,
 	NE,
 }

--- a/frontend/parser/Cargo.toml
+++ b/frontend/parser/Cargo.toml
@@ -10,4 +10,3 @@ pest = "2.7.5"
 pest_derive = "2.7.5"
 utils = { path = "../../utils" }
 ast = { path = "../ast" }
-lazy_static = "1.4.0"

--- a/frontend/parser/src/parser.rs
+++ b/frontend/parser/src/parser.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, hash::Hash};
 
 use ast::{tree::*, BinaryOp, FuncType, UnaryOp, VarType};
-use pest::{iterators::Pair, pratt_parser::PrattParser, Parser};
+use pest::{iterators::Pair, Parser};
 use pest_derive::Parser;
 use utils::SysycError;
 
@@ -17,10 +17,10 @@ fn map_binary_op(pair: &Pair<Rule>) -> BinaryOp {
 		Rule::Mul => BinaryOp::Mul,
 		Rule::Div => BinaryOp::Div,
 		Rule::Mod => BinaryOp::Mod,
-		Rule::LQ => BinaryOp::LQ,
+		Rule::LT => BinaryOp::LT,
 		Rule::LE => BinaryOp::LE,
 		Rule::GE => BinaryOp::GE,
-		Rule::GQ => BinaryOp::GQ,
+		Rule::GT => BinaryOp::GT,
 		Rule::EQ => BinaryOp::EQ,
 		Rule::NE => BinaryOp::NE,
 		_ => unreachable!(),
@@ -70,21 +70,6 @@ fn parse_dim_list(pair: Pair<Rule>, min_dims: usize) -> Option<NodeList> {
 	}
 }
 
-lazy_static::lazy_static! {
-	static ref PRATT_PARSER: PrattParser<Rule> = {
-		use pest::pratt_parser::{Assoc::*, Op};
-		PrattParser::new()
-			.op(Op::infix(Rule::LOr, Left))
-			.op(Op::infix(Rule::LAnd, Left))
-			.op(Op::infix(Rule::EQ, Left) | Op::infix(Rule::NE, Left))
-			.op(Op::infix(Rule::LQ, Left) | Op::infix(Rule::LE, Left)
-				| Op::infix(Rule::GE, Left) | Op::infix(Rule::GQ, Left))
-			.op(Op::infix(Rule::Add, Left) | Op::infix(Rule::Sub, Left))
-			.op(Op::infix(Rule::Mul, Left) | Op::infix(Rule::Div, Left) | Op::infix(Rule::Mod, Left))
-			.op(Op::prefix(Rule::UnaryAdd) | Op::prefix(Rule::UnarySub) | Op::prefix(Rule::UnaryNot))
-	};
-}
-
 fn parse_func_call(pair: Pair<Rule>) -> Node {
 	let mut pairs = pair.into_inner();
 	let func_call = FuncCall {
@@ -122,45 +107,38 @@ fn parse_primary_expr(pair: Pair<Rule>) -> Node {
 	}
 }
 
-fn parse_binary_expr(lhs: Node, op: Pair<Rule>, rhs: Node) -> Node {
-	Box::new(BinaryExpr {
-		_attrs: HashMap::new(),
-		lhs,
-		op: map_binary_op(&op),
-		rhs,
-	})
-}
-
-fn parse_unary_expr(op: Pair<Rule>, rhs: Node) -> Node {
-	Box::new(UnaryExpr {
-		_attrs: HashMap::new(),
-		op: map_unary_op(&op),
-		rhs,
-	})
-}
-
-fn parse_expr_no_assign(pair: Pair<Rule>) -> Node {
-	PRATT_PARSER
-		.map_primary(|v| parse_primary_expr(v))
-		.map_infix(|lhs, op, rhs| parse_binary_expr(lhs, op, rhs))
-		.map_prefix(|op, rhs| parse_unary_expr(op, rhs))
-		.parse(pair.into_inner())
+fn parse_unary_expr(pair: Pair<Rule>) -> Node {
+	let mut pairs = pair.into_inner();
+	let x = pairs.next().unwrap();
+	if x.as_rule() == Rule::Primary {
+		parse_primary_expr(x.into_inner().next().unwrap())
+	} else {
+		let rhs = pairs.next().unwrap();
+		Box::new(UnaryExpr {
+			_attrs: HashMap::new(),
+			op: map_unary_op(&x),
+			rhs: parse_unary_expr(rhs),
+		})
+	}
 }
 
 fn parse_expr(pair: Pair<Rule>) -> Node {
+	if pair.as_rule() == Rule::UnaryExpr {
+		return parse_unary_expr(pair);
+	}
 	let mut pairs = pair.into_inner();
-	let lhs = parse_expr_no_assign(pairs.next().unwrap());
+	let lhs = pairs.next();
 	let op = pairs.next();
 	let rhs = pairs.next();
-	if op.is_some() {
+	if let Some(op) = op {
 		Box::new(BinaryExpr {
 			_attrs: HashMap::new(),
-			lhs,
-			op: map_binary_op(&op.unwrap()),
+			lhs: parse_expr(lhs.unwrap()),
+			op: map_binary_op(&op),
 			rhs: parse_expr(rhs.unwrap()),
 		})
 	} else {
-		lhs
+		parse_expr(lhs.unwrap())
 	}
 }
 
@@ -188,7 +166,7 @@ fn parse_var_def(pair: Pair<Rule>) -> Node {
 		dim_list: None,
 		init: None,
 	};
-	for pair in pairs.into_iter() {
+	for pair in pairs {
 		match pair.as_rule() {
 			Rule::DimList => var_def.dim_list = parse_dim_list(pair, 1),
 			Rule::Expr => var_def.init = Some(parse_init_val(pair)),
@@ -207,7 +185,7 @@ fn parse_decl(pair: Pair<Rule>) -> Node {
 			_attrs: HashMap::new(),
 			is_const,
 			type_t: parse_var_type(pairs.next().unwrap()),
-			defs: pairs.into_iter().map(parse_var_def).collect(),
+			defs: pairs.map(parse_var_def).collect(),
 		}
 	}
 	match pair.as_rule() {
@@ -310,15 +288,12 @@ fn parse_comp_unit(pair: Pair<Rule>) -> Option<Node> {
 	}
 }
 
+#[allow(unused)]
 pub fn parse(str: &str) -> Result<Program, SysycError> {
 	let progam = SysycParser::parse(Rule::Program, str)
 		.map_err(|e| SysycError::DecafLexError(e.to_string()))?;
 	Ok(Program {
 		_attrs: HashMap::new(),
-		comp_units: progam
-			.into_iter()
-			.map(parse_comp_unit)
-			.filter_map(|x| x)
-			.collect(),
+		comp_units: progam.into_iter().filter_map(parse_comp_unit).collect(),
 	})
 }

--- a/frontend/parser/src/sysy2022.pest
+++ b/frontend/parser/src/sysy2022.pest
@@ -25,9 +25,9 @@ Sub = { "-" }
 Mul = { "*" }
 Div = { "/" }
 Mod = { "%" }
-LQ = { "<" }
+LT = { "<" }
 LE = { "<=" }
-GQ = { ">" }
+GT = { ">" }
 GE = { ">=" }
 EQ = { "==" }
 NE = { "!=" }
@@ -43,9 +43,6 @@ Break = { "break" }
 Continue = { "continue" }
 Return = { "return" ~ Expr? }
 
-BinaryOp = _{
-  Add | Sub | Mul | Div | Mod | LQ | LE | GE | GQ | EQ | NE
-}
 UnaryOp = _{
   UnaryAdd | UnarySub | UnaryNot
 }
@@ -90,9 +87,15 @@ Stmt = {
 
 Lval = { Identifier ~ DimList }
 FuncCall = { Identifier ~ "(" ~ RealParams ~ ")"}
-Primary = _{ "(" ~ Expr ~ ")" | Number | FuncCall | Lval }
-Atom = _{ UnaryOp? ~ Primary }
-NoAssignExpr = { Atom ~ (BinaryOp ~ Atom)* }
-Expr = { NoAssignExpr ~ (Assign ~ Expr)? }
+Primary = { "(" ~ Expr ~ ")" | Number | FuncCall | Lval }
+UnaryExpr = { Primary | UnaryOp ~ UnaryExpr }
+MulExpr = { UnaryExpr ~ ((Mul | Div | Mod) ~ MulExpr)? }
+AddExpr = { MulExpr ~ ((Add | Sub) ~ AddExpr)? }
+RelExpr = { AddExpr ~ ((GE | GT | LE | LT) ~ RelExpr)? }
+EqExpr = { RelExpr ~ ((EQ | NE) ~ EqExpr)? }
+LAndExpr = { EqExpr ~ (LAnd ~ LAndExpr)? }
+LOrExpr = { LAndExpr ~ (LOr ~ LOrExpr)? }
+BinaryExpr = { LOrExpr ~ (Assign ~ BinaryExpr)? }
+Expr = { BinaryExpr | UnaryExpr }
 
 Program = _{ SOI ~ (CompUnit)* ~ EOI }


### PR DESCRIPTION
移除了 pratt parser 方法，使用文法控制操作符优先级。
可以解析以下例子：
```cpp
int main() {
  int a = 2;
  int b = 3;
  if (a > b) {
		a = a + b;
  }
  if (a >= b) {
		a = a - b;
  }
  if (a < b) {
		a = a * b;
  }
  if (a <= b) {
		a = a / b;
  }
	a = a % b;
	float c = 1.2;
	c = c * (a + b);
	int d[10] = {1,2,3};
	d[0] = c - (10 + d[0]);
	while(c < d[0]) {
		c = c + !a;
	}
	return d[a];
}
```