### PR TITLE
Fix array global

### DIFF
--- a/frontend/ast/src/lib.rs
+++ b/frontend/ast/src/lib.rs
@@ -16,8 +16,13 @@ pub fn val_2_node(value: &Value) -> Node {
 
 pub fn shirink(node: &mut Node) {
 	if let Some(value) = node.get_attr("value") {
-		let v = value.clone();
-		*node = val_2_node(&value.into());
-		node.set_attr("value", v);
+		match value {
+			attr::Attr::Value(Value::Float(_)) | attr::Attr::Value(Value::Int(_)) => {
+				let v = value.clone();
+				*node = val_2_node(&value.into());
+				node.set_attr("value", v);
+			}
+			_ => {}
+		}
 	}
 }

--- a/frontend/attr/src/lib.rs
+++ b/frontend/attr/src/lib.rs
@@ -9,6 +9,8 @@ pub enum Attr {
 	VarSymbol(VarSymbol),
 	VarType(VarType),
 	Value(Value),
+	InitValListDepth(usize),
+	InitValLIstPosition(usize),
 }
 
 pub trait Attrs {

--- a/frontend/irgen/src/impls.rs
+++ b/frontend/irgen/src/impls.rs
@@ -32,6 +32,7 @@ impl IRGenerator {
 			is_global: false,
 			loading_array: None,
 			loading_type: None,
+			initialized_stack_array_item: HashSet::new(),
 		}
 	}
 	pub fn to_rrvm(mut self, mut program: Program) -> Result<LlvmProgram> {

--- a/frontend/irgen/src/impls.rs
+++ b/frontend/irgen/src/impls.rs
@@ -30,6 +30,8 @@ impl IRGenerator {
 			states: Vec::new(),
 			weights: Vec::new(),
 			is_global: false,
+			loading_array: None,
+			loading_type: None,
 		}
 	}
 	pub fn to_rrvm(mut self, mut program: Program) -> Result<LlvmProgram> {
@@ -46,6 +48,7 @@ impl IRGenerator {
 		if target == value.get_type() {
 			return value;
 		}
+
 		let (from_type, to_type, op) = match target {
 			I32 => (F32, I32, Float2Int),
 			F32 => (I32, F32, Int2Float),

--- a/frontend/irgen/src/impls.rs
+++ b/frontend/irgen/src/impls.rs
@@ -29,6 +29,7 @@ impl IRGenerator {
 			ret_type: FuncRetType::Void,
 			states: Vec::new(),
 			weights: Vec::new(),
+			is_global: false,
 		}
 	}
 	pub fn to_rrvm(mut self, mut program: Program) -> Result<LlvmProgram> {

--- a/frontend/irgen/src/utils.rs
+++ b/frontend/irgen/src/utils.rs
@@ -61,3 +61,41 @@ pub fn func_type_convert(from: &value::FuncRetType) -> VarType {
 		FuncRetType::Void => VarType::Void,
 	}
 }
+
+pub fn var_type_to_ptr(from: &VarType) -> VarType {
+	match from {
+		VarType::I32 => VarType::I32Ptr,
+		VarType::F32 => VarType::F32Ptr,
+		VarType::I32Ptr => VarType::I32Ptr,
+		VarType::F32Ptr => VarType::F32Ptr,
+		VarType::Void => unreachable!(),
+	}
+}
+
+pub fn var_type_to_scalar(from: &VarType) -> VarType {
+	match from {
+		VarType::I32 => VarType::I32,
+		VarType::F32 => VarType::F32,
+		VarType::I32Ptr => VarType::I32,
+		VarType::F32Ptr => VarType::F32,
+		VarType::Void => unreachable!(),
+	}
+}
+
+pub fn is_global(temp: &llvm::Value) -> bool {
+	if let llvm::Value::Temp(t) = temp {
+		t.is_global
+	} else {
+		false
+	}
+}
+
+pub fn is_ptr(var_type: &VarType) -> bool {
+	match var_type {
+		VarType::I32 => false,
+		VarType::F32 => false,
+		VarType::I32Ptr => true,
+		VarType::F32Ptr => true,
+		VarType::Void => unreachable!(),
+	}
+}

--- a/frontend/irgen/src/utils.rs
+++ b/frontend/irgen/src/utils.rs
@@ -99,3 +99,11 @@ pub fn is_ptr(var_type: &VarType) -> bool {
 		VarType::Void => unreachable!(),
 	}
 }
+
+pub fn get_zero(var_type: &VarType) -> llvm::Value {
+	match var_type {
+		VarType::I32 => llvm::Value::Int(0),
+		VarType::F32 => llvm::Value::Float(0.0),
+		_ => unreachable!(),
+	}
+}

--- a/frontend/irgen/src/visitor.rs
+++ b/frontend/irgen/src/visitor.rs
@@ -99,7 +99,6 @@ impl Visitor for IRGenerator {
 		if let Some(init) = node.init.as_mut() {
 			self.symbol_table.set(symbol.id, var_type.default_value());
 			init.accept(self)?;
-			let (mut cfg, value, _) = self.stack.pop().unwrap();
 			if symbol.var_type.is_array() {
 				let temp = self.mgr.new_temp(var_type_to_ptr(&var_type), false); //往这个temp里store
 				self.symbol_table.set(symbol.id, temp.clone().into());

--- a/frontend/namer/src/visitor.rs
+++ b/frontend/namer/src/visitor.rs
@@ -29,10 +29,12 @@ pub struct Namer {
 }
 
 impl Namer {
-	pub fn transform(&mut self, program: &mut Program) -> Result<()> {
+	pub fn transform(
+		&mut self,
+		program: &mut Program,
+	) -> Result<HashMap<String, Vec<InitValueItem>>> {
 		program.accept(self)?;
-		dbg!(&self.global_init_values);
-		Ok(())
+		Ok(self.global_init_values.to_owned())
 	}
 }
 
@@ -102,6 +104,7 @@ impl Visitor for Namer {
 		let var_type: VarType = (!is_const, btype, dim_list.clone()).into();
 
 		let symbol = self.mgr.new_var_symbol(&node.ident, var_type);
+
 		let symbol_id = symbol.id;
 		let symbol_ident =
 			symbol.ident.clone().split_whitespace().next().unwrap().to_string();

--- a/frontend/parser/src/sysy2022.pest
+++ b/frontend/parser/src/sysy2022.pest
@@ -51,7 +51,7 @@ UnaryOp = _{
   UnaryAdd | UnarySub | UnaryNot | UnaryBitNot
 }
 
-CompUnit = _{ FuncDecl } // TODO: global variable: CompUnit = _{ Decl | FuncDecl }
+CompUnit = _{ Decl | FuncDecl }
 DimList = { ("[" ~ Expr ~ "]")* }
 
 Decl = { ConstDecl | VarDecl }

--- a/frontend/value/src/lib.rs
+++ b/frontend/value/src/lib.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 pub mod calc;
 pub mod calc_type;
 pub mod impls;
@@ -24,8 +26,8 @@ pub struct VarType {
 }
 
 pub type FuncType = (FuncRetType, Vec<VarType>);
-pub type IntPtr = (Vec<usize>, Vec<i32>);
-pub type FloatPtr = (Vec<usize>, Vec<f32>);
+pub type IntPtr = (Vec<usize>, HashMap<usize, i32>);
+pub type FloatPtr = (Vec<usize>, HashMap<usize, f32>);
 
 #[derive(Clone, Debug)]
 pub enum Value {

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,9 +35,10 @@ fn step_parse(name: Option<String>) -> Result<Program> {
 }
 
 fn step_llvm(mut program: Program, level: i32) -> Result<LlvmProgram> {
-	Namer::default().transform(&mut program)?;
+	let global_value = Namer::default().transform(&mut program)?;
 	Typer::default().transform(&mut program)?;
 	let mut program = IRGenerator::new().to_rrvm(program)?;
+	program.global_values = global_value;
 	match level {
 		0 => Optimizer0::new().apply(&mut program)?,
 		1 => Optimizer1::new().apply(&mut program)?,

--- a/utils/llvm/src/llvmop.rs
+++ b/utils/llvm/src/llvmop.rs
@@ -4,7 +4,7 @@ use sysyc_derive::Fuyuki;
 
 use crate::{llvmvar::VarType, temp::Temp};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Value {
 	Int(i32),
 	Float(f32),

--- a/utils/llvm/src/temp.rs
+++ b/utils/llvm/src/temp.rs
@@ -55,4 +55,12 @@ impl TempManager {
 		self.total += 1;
 		Temp::new(self.total, var_type, is_global)
 	}
+	pub fn new_temp_with_name(
+		&mut self,
+		name: String,
+		var_type: VarType,
+	) -> Temp {
+		self.total += 1;
+		Temp::new(name, var_type, true)
+	}
 }

--- a/utils/rrvm/src/impls.rs
+++ b/utils/rrvm/src/impls.rs
@@ -37,6 +37,10 @@ impl<T: InstrTrait<U>, U: TempTrait> Display for RrvmProgram<T, U> {
 		let funcs =
 			self.funcs.iter().map(|v| v.to_string()).collect::<Vec<_>>().join("\n");
 
+		for item in &self.global_values {
+			writeln!(f, "{:?}", &item)?;
+		}
+
 		write!(f, "{}", funcs)
 	}
 }

--- a/utils/rrvm/src/program.rs
+++ b/utils/rrvm/src/program.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
+
 use instruction::{riscv::RiscvInstr, temp};
 use llvm::LlvmInstr;
-use utils::{InstrTrait, TempTrait};
+use utils::{InitValueItem, InstrTrait, TempTrait};
 
 use crate::func::RrvmFunc;
 
@@ -10,13 +12,16 @@ pub type RiscvFunc = RrvmFunc<RiscvInstr, temp::Temp>;
 pub type RiscvProgram = RrvmProgram<RiscvInstr, temp::Temp>;
 
 pub struct RrvmProgram<T: InstrTrait<U>, U: TempTrait> {
-	// pub global_vars: Vec<>
+	pub global_values: HashMap<String, Vec<InitValueItem>>,
 	pub funcs: Vec<RrvmFunc<T, U>>,
 }
 
 impl<T: InstrTrait<U>, U: TempTrait> RrvmProgram<T, U> {
 	pub fn new() -> Self {
-		Self { funcs: Vec::new() }
+		Self {
+			funcs: Vec::new(),
+			global_values: HashMap::new(),
+		}
 	}
 }
 


### PR DESCRIPTION
添加生成IR为止的以下功能：

0 数组初始化列表的解析。包括相应的隐式类型转换。
1 const变量（以及const数组中的项）作为常量（如数组长度）。
2 global变量初始化值的解析

修正一些bug：
0 数组传参时panic
1 使用全局变量时有错误的类型转换语句