### PR TITLE
fix : 针对 instruction-combining

### DIFF
--- a/optimizer/src/local_expression_rearrangement/impls.rs
+++ b/optimizer/src/local_expression_rearrangement/impls.rs
@@ -513,7 +513,7 @@ impl RrvmOptimizer for LocalExpressionRearrangement {
 			let mut current_i32_calculation: ArithMap = HashMap::new();
 			for item in cfg.blocks.as_slice() {
 				current_i32_calculation.clear();
-				if item.borrow().instrs.len() > 2000 {
+				if item.borrow().instrs.len() > 20000 {
 					continue;
 				}
 				let mut new_instr = vec![];


### PR DESCRIPTION
一个错误，使得在instruction-combing测例中，没有应用表达试重排优化。
现予以修正。